### PR TITLE
Adding the concept of Upcoming Game in the list

### DIFF
--- a/imports/ui/MatchEntry.jsx
+++ b/imports/ui/MatchEntry.jsx
@@ -78,8 +78,8 @@ class WinnerSelect extends Component {
         </div>
 
         <div style={{paddingTop: 7}}>
-          <input type="radio" name="winner" value="Future Game"
-            onChange={this.handleChange} checked={this.state.winner === "Future Game"}/> Future Game
+          <input type="radio" name="winner" value="Upcoming Game"
+            onChange={this.handleChange} checked={this.state.winner === "Upcoming Game"}/> Upcoming Game
         </div>
       </div>
     );
@@ -121,7 +121,7 @@ export default class MatchEntry extends Component {
     if (this.state.winner !== this.state.team1 &&
         this.state.winner !== this.state.team2 &&
         this.state.winner !== 'Draw' &&
-        this.state.winner !== 'Future Game') {
+        this.state.winner !== 'Upcoming Game') {
       alert('Winner needs to be set!');
       return;
     }

--- a/imports/ui/MatchEntry.jsx
+++ b/imports/ui/MatchEntry.jsx
@@ -76,6 +76,11 @@ class WinnerSelect extends Component {
           <input type="radio" name="winner" value="Draw"
             onChange={this.handleChange} checked={this.state.winner === "Draw"}/> Draw
         </div>
+
+        <div style={{paddingTop: 7}}>
+          <input type="radio" name="winner" value="Future Game"
+            onChange={this.handleChange} checked={this.state.winner === "Future Game"}/> Future Game
+        </div>
       </div>
     );
   }
@@ -115,7 +120,8 @@ export default class MatchEntry extends Component {
 
     if (this.state.winner !== this.state.team1 &&
         this.state.winner !== this.state.team2 &&
-        this.state.winner !== 'Draw') {
+        this.state.winner !== 'Draw' &&
+        this.state.winner !== 'Future Game') {
       alert('Winner needs to be set!');
       return;
     }

--- a/imports/ui/MatchList.jsx
+++ b/imports/ui/MatchList.jsx
@@ -31,8 +31,8 @@ class MatchList extends Component {
         <td>{this.renderTeam(match.team2)}</td>
         <td>{match.date}</td>
         <td>{match.phase}</td>
-        {(match.winner != 'Future Game') &&  <td>{match.team1goals}-{match.team2goals}</td>}
-        {(match.winner == 'Future Game') &&  <td>{match.date}</td>}
+        {(match.winner != 'Upcoming Game') &&  <td>{match.team1goals}-{match.team2goals}</td>}
+        {(match.winner == 'Upcoming Game') &&  <td>-</td>}
         <td>{this.renderTeam(match.winner)}</td>
         <td>{match.created}</td>
         {this.props.admin &&

--- a/imports/ui/MatchList.jsx
+++ b/imports/ui/MatchList.jsx
@@ -31,7 +31,8 @@ class MatchList extends Component {
         <td>{this.renderTeam(match.team2)}</td>
         <td>{match.date}</td>
         <td>{match.phase}</td>
-        <td>{match.team1goals}-{match.team2goals}</td>
+        {(match.winner != 'Future Game') &&  <td>{match.team1goals}-{match.team2goals}</td>}
+        {(match.winner == 'Future Game') &&  <td>{match.date}</td>}
         <td>{this.renderTeam(match.winner)}</td>
         <td>{match.created}</td>
         {this.props.admin &&

--- a/imports/ui/MatchList.jsx
+++ b/imports/ui/MatchList.jsx
@@ -34,7 +34,6 @@ class MatchList extends Component {
         {(match.winner != 'Upcoming Game') &&  <td>{match.team1goals}-{match.team2goals}</td>}
         {(match.winner == 'Upcoming Game') &&  <td>-</td>}
         <td>{this.renderTeam(match.winner)}</td>
-        <td>{match.created}</td>
         {this.props.admin &&
           <td>
             <div>
@@ -61,7 +60,6 @@ class MatchList extends Component {
                 <th>Phase</th>
                 <th>Score</th>
                 <th>Winner</th>
-                <th>Creation date</th>
                 {this.props.admin &&
                   <th>Action</th>
                 }

--- a/server/server.js
+++ b/server/server.js
@@ -33,7 +33,7 @@ function UpdateScores() {
   });
 
   Matchs.find({}).map(function(match) {
-    if ((match.winner != "Draw") && (match.winner != "Future Game")) {
+    if ((match.winner != "Draw") && (match.winner != "Upcoming Game")) {
       teams[match.winner] += 3;
     }
     else {

--- a/server/server.js
+++ b/server/server.js
@@ -38,8 +38,8 @@ function UpdateScores() {
     }
     else {
       if (match.winner === "Draw") {
-      teams[match.team1] += 1;
-      teams[match.team2] += 1;
+        teams[match.team1] += 1;
+        teams[match.team2] += 1;
       }
     }
 

--- a/server/server.js
+++ b/server/server.js
@@ -33,12 +33,14 @@ function UpdateScores() {
   });
 
   Matchs.find({}).map(function(match) {
-    if (match.winner != "Draw") {
+    if ((match.winner != "Draw") && (match.winner != "Future Game")) {
       teams[match.winner] += 3;
     }
     else {
+      if (match.winner === "Draw") {
       teams[match.team1] += 1;
       teams[match.team2] += 1;
+      }
     }
 
     let goalMultiplier = 0.3;


### PR DESCRIPTION
@lu22do 
What do you think about this feature?
We (the admin) can enter the 48 group phase games in advance as "Future Game". No points are being gained for those games, and the match list will show when they will be instead of the score.

The player will be able to see the upcoming games
The admin will only have to update 2,3 or 4 scores every day, and not enter the whole game

What do you think?