### PR TITLE
change format for Match List to not show the hours

### DIFF
--- a/imports/ui/MatchList.jsx
+++ b/imports/ui/MatchList.jsx
@@ -84,7 +84,7 @@ export default withTracker(props => {
   const matchs = Matchs.find({}, {sort:{date: 1}}).map(function(match) {
     match.created = moment(match.created).calendar();
     if (match.date) {
-      match.date = moment(match.date).calendar();
+      match.date = moment(match.date).format('dddd, MMMM Do');
     }
     return match;
   });


### PR DESCRIPTION
As we don't have the time of the match (only the day) , the current format using .calendar() is showing than at 12:00AM 
This format will show the day like : Saturday, June 16th

@lu22do 